### PR TITLE
Add docker volumes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - docker build -t personal-website .
 
 script:
-  - docker run personal-website
+  - docker run -v $(pwd)/public:/app/public personal-website
 
 deploy:
   provider: pages


### PR DESCRIPTION
Map the necessary docker volumes so that the build files are saved, and are then recognised as part of the deploy process, and sent to GitHub Pages.